### PR TITLE
feat: footer stays right above keyboard ui

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import LoginModal from "./pages/LoginPage/LoginModal";
 import InviteSpace from "./pages/SpacePage/InviteSpace";
 import InviteSpace2 from "./pages/SpacePage/InviteSpace2";
 import SpecialVoiceRoom from "./pages/VoiceRoomPage/SpecialVoiceRoom";
+import WritePostPage from "./pages/WritePostPage";
 
 // will we need constant path in later..?
 // const PATH = {
@@ -69,7 +70,7 @@ const LayoutContainer = styled.div`
   margin: 0 auto;
 
   #content {
-    min-height: calc(100vh - 3.75rem);
+    height: calc(100vh - 3.75rem);
   }
 `;
 
@@ -154,6 +155,10 @@ function App() {
     { path: "/member/:id", element: <HomePageProfile />, hasBottombar: false },
   ];
 
+  const routes_children_write = [
+    { path: "/write", element: <WritePostPage />, hasBottombar: false },
+  ];
+
   const routes_children = [
     { path: "/", element: <HomePage />, hasBottomBar: true },
     ...routes_children_chat,
@@ -163,6 +168,7 @@ function App() {
     ...routes_children_space,
     ...routes_children_login,
     ...routes_children_home,
+    ...routes_children_write,
     { path: "/*", element: <HomePage />, hasBottomBar: true },
   ];
 

--- a/src/components/KeyboardAccessoryView.tsx
+++ b/src/components/KeyboardAccessoryView.tsx
@@ -17,7 +17,6 @@ const KeyboardAccessoryView: React.FC<KeyboardAccessoryViewProps> = ({ children 
     const visualViewportHeight = window.visualViewport?.height;
     if (visualViewportHeight && divRef.current) {
       divRef.current.style.height = `${visualViewportHeight - 30}px`;
-      window.scrollTo(0, 40);
     }
   };
 

--- a/src/components/KeyboardAccessoryView.tsx
+++ b/src/components/KeyboardAccessoryView.tsx
@@ -7,7 +7,7 @@ export interface KeyboardAccessoryViewProps {
 
 const StyledKeyboardAccessoryView = styled.div`
   position: absolute;
-  bottom: 100px;
+  bottom: 10px;
 `;
 
 const KeyboardAccessoryView: React.FC<KeyboardAccessoryViewProps> = ({ children }) => {

--- a/src/components/KeyboardAccessoryView.tsx
+++ b/src/components/KeyboardAccessoryView.tsx
@@ -30,7 +30,6 @@ const KeyboardAccessoryView: React.FC<KeyboardAccessoryViewProps> = ({ children 
     }
 
     return () => {
-      console.log("visualViewport unregistered");
       resizeAbortController.abort();
     };
   }, []);

--- a/src/components/KeyboardAccessoryView.tsx
+++ b/src/components/KeyboardAccessoryView.tsx
@@ -1,0 +1,42 @@
+import React, { ReactNode, useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import styled from "styled-components";
+
+export interface KeyboardAccessoryViewProps {
+  children: ReactNode;
+}
+
+const StyledKeyboardAccessoryView = styled.div`
+  position: absolute;
+  bottom: 100px;
+`;
+
+const KeyboardAccessoryView: React.FC<KeyboardAccessoryViewProps> = ({ children }) => {
+  const divRef = useRef<HTMLDivElement>(null);
+
+  const handleVisualViewportResize = (event: Event) => {
+    const visualViewportHeight = window.visualViewport?.height;
+    if (visualViewportHeight && divRef.current) {
+      divRef.current.style.height = `${visualViewportHeight - 30}px`;
+      window.scrollTo(0, 40);
+    }
+  };
+
+  useEffect(() => {
+    const resizeAbortController = new AbortController();
+
+    if (visualViewport) {
+      visualViewport.addEventListener("resize", handleVisualViewportResize, {
+        signal: resizeAbortController.signal,
+      });
+    }
+
+    return () => {
+      console.log("visualViewport unregistered");
+      resizeAbortController.abort();
+    };
+  }, []);
+
+  return <StyledKeyboardAccessoryView>{children}</StyledKeyboardAccessoryView>;
+};
+
+export default KeyboardAccessoryView;

--- a/src/components/KeyboardAccessoryView.tsx
+++ b/src/components/KeyboardAccessoryView.tsx
@@ -11,29 +11,6 @@ const StyledKeyboardAccessoryView = styled.div`
 `;
 
 const KeyboardAccessoryView: React.FC<KeyboardAccessoryViewProps> = ({ children }) => {
-  const divRef = useRef<HTMLDivElement>(null);
-
-  const handleVisualViewportResize = (event: Event) => {
-    const visualViewportHeight = window.visualViewport?.height;
-    if (visualViewportHeight && divRef.current) {
-      divRef.current.style.height = `${visualViewportHeight - 30}px`;
-    }
-  };
-
-  useEffect(() => {
-    const resizeAbortController = new AbortController();
-
-    if (visualViewport) {
-      visualViewport.addEventListener("resize", handleVisualViewportResize, {
-        signal: resizeAbortController.signal,
-      });
-    }
-
-    return () => {
-      resizeAbortController.abort();
-    };
-  }, []);
-
   return <StyledKeyboardAccessoryView>{children}</StyledKeyboardAccessoryView>;
 };
 

--- a/src/hooks/useVisualViewportResize.ts
+++ b/src/hooks/useVisualViewportResize.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from "react";
+
+const useVisualViewportResize = () => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleVisualViewportResize = (event: Event) => {
+    const visualViewportHeight = window.visualViewport?.height;
+    if (visualViewportHeight && ref.current) {
+      ref.current.style.transition = "height 0.3s ease-out";
+      ref.current.style.height = `${visualViewportHeight}px`;
+    }
+  };
+
+  useEffect(() => {
+    const resizeAbortController = new AbortController();
+
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener("resize", handleVisualViewportResize, {
+        signal: resizeAbortController.signal,
+      });
+    }
+
+    return () => {
+      resizeAbortController.abort();
+    };
+  }, []);
+
+  return ref;
+};
+
+export default useVisualViewportResize;

--- a/src/pages/WritePostPage/index.tsx
+++ b/src/pages/WritePostPage/index.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styled from "styled-components";
+
+import KeyboardAccessoryView from "@/components/KeyboardAccessoryView";
+import useVisualViewportResize from "@/hooks/useVisualViewportResize";
+
+const StyledInput = styled.input`
+  font-size: 16px;
+  width: 100%;
+  height: 32px;
+  border: 1px solid #000;
+`;
+
+const StyledDiv = styled.div`
+  height: 100%;
+  position: relative;
+`;
+
+export default function WritePostPage() {
+  const ref = useVisualViewportResize();
+
+  return (
+    <StyledDiv ref={ref}>
+      <StyledInput type="text" />
+      <KeyboardAccessoryView>
+        <div>안드로이드</div>
+        <div>안드로이드</div>
+        <div>안드로이드</div>
+        <div>안드로이드</div>
+        <div>안드로이드</div>
+      </KeyboardAccessoryView>
+    </StyledDiv>
+  );
+}


### PR DESCRIPTION
## Summary
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 글쓰기 페이지에서, 태그가 항상 키보드 위에 위치할 수 있도록 useVisualViewportResize 훅을 추가했습니다. visual viewport의 높이에 따라 같이 높이가 줄어들어야 요소에 hook의 반환값 ref를 추가하면 됩니다!

<!-- 연관된 이슈: #(Issue Number)  #15 와 같이 작성하면 됩니다.-->

## PR 유형 및 세부 작업 내용
- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

- main section의 min-heigh를 height로 변경하였습니다. 왜냐하면, parent가 min-height만 설정되어 있을 때는 child의 height 100%가 동작하지 않아 Parent height만큼 커지지 않기 때문입니다. 따라서 child의 height를 parent만큼 늘리기 위해 해당 조정을 하였습니다.
- 애니메이션 같은 경우에는 키보드 올라올 때는 자연스럽게 되는데, 키보드 내려갈 때는 키보드가 **완전히 화면에서 사라진 뒤에** 이벤트가 발생이 이루어져서 딜레이가 있습니다.

## 작동 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/89184866-c2ed-4d6d-8b29-3c60656261c3)


## 리뷰 요구사항 (선택)
-->