### PR TITLE
하드코드된 변수 spaceId 상수로 교체

### DIFF
--- a/documents/pull-request/replace_space_id_with_constant.md
+++ b/documents/pull-request/replace_space_id_with_constant.md
@@ -1,0 +1,32 @@
+## Summary
+하드코딩된 space ID 값(1과 3)을 중앙 집중식 SPACE_ID 상수로 대체하는 작업을 수행했습니다. 이를 통해 향후 space ID 값을 변경해야 할 경우 코드베이스 전체에서 모든 인스턴스를 찾아 수정하는 대신 한 곳에서만 수정하면 되므로 유지보수성이 향상됩니다.
+
+## PR 유형 및 세부 작업 내용
+- [x] 코드 리팩토링
+
+### 세부 내용
+1. 새로운 상수 파일 생성 (`src/utils/constants.ts`)에 SPACE_ID 상수 정의 (값: 3)
+   - 애플리케이션 전체에서 사용할 수 있는 중앙 집중식 상수 파일 생성
+
+2. 하드코딩된 space ID 값 3을 SPACE_ID 상수로 대체:
+   - `src/pages/ChatPage/ChattingPage/ChattingPage.tsx`
+     - `const spaceId = Number(localStorage.getItem("spaceId")) || 3;` → `const spaceId = Number(localStorage.getItem("spaceId")) || SPACE_ID;`
+   - `src/pages/ChatPage/ChatCreatePage/ChatCreatePage.tsx`
+     - `const [spaceId, setSpaceId] = useState<number>(3);` → `const [spaceId, setSpaceId] = useState<number>(SPACE_ID);`
+   - `src/pages/VoiceRoomPage/EditVoiceRoomPage.tsx`
+     - `VrEditApi(3, newRoomInfo)` → `VrEditApi(SPACE_ID, newRoomInfo)`
+   - `src/pages/BoardPage/BoardRegisterPage/BoardRegisterPage.tsx`
+     - `Number.parseInt(spaceId) || 3,` → `Number.parseInt(spaceId) || SPACE_ID,`
+   - `src/pages/PayPage/ReqDataDiv.tsx`에서 사용되지 않는 `const spaceID = 3;` 변수 제거
+
+3. 하드코딩된 space ID 값 1을 SPACE_ID 상수로 대체:
+   - `src/pages/QRPage/QRPage.tsx`
+     - `const { mutate: joinEvent } = useJoinEvent(1, Number(id));` → `const { mutate: joinEvent } = useJoinEvent(SPACE_ID, Number(id));`
+     - `const { data } = useEventQuery(1, Number(id), { refetchInterval: 10000 });` → `const { data } = useEventQuery(SPACE_ID, Number(id), { refetchInterval: 10000 });`
+   - `src/pages/QRPage/QRDetail.tsx`
+     - `const { data } = useEventQuery(1, Number(id), { refetchInterval: 10000 });` → `const { data } = useEventQuery(SPACE_ID, Number(id), { refetchInterval: 10000 });`
+   - `src/pages/QRPage/QRHome.tsx`
+     - `const { mutate: deleteEvent } = useDeleteEvent(1);` → `const { mutate: deleteEvent } = useDeleteEvent(SPACE_ID);`
+     - `const { data } = useEventsQuery(1, { refetchInterval: 10000 });` → `const { data } = useEventsQuery(SPACE_ID, { refetchInterval: 10000 });`
+
+이 변경으로 코드의 일관성이 향상되고, 향후 space ID 값을 변경해야 할 경우 한 곳에서만 수정하면 되므로 유지보수가 용이해집니다. 또한 QR 페이지에서 사용하던 space ID 값 1을 프로젝트 전체에서 사용하는 값 3으로 통일하여 일관성을 높였습니다.

--- a/src/pages/BoardPage/BoardRegisterPage/BoardRegisterPage.tsx
+++ b/src/pages/BoardPage/BoardRegisterPage/BoardRegisterPage.tsx
@@ -8,6 +8,7 @@ import gallery from "@/assets/Board/gallery.svg";
 import link from "@/assets/Board/link.svg";
 import CheckBox from "@/components/CheckBox";
 import TopBarText, { LeftEnum } from "@/components/TopBarText";
+import { SPACE_ID } from "@/utils/constants";
 
 const BoardRegisterBtn = styled.button`
   color: var(--Foundation-Gray-gray500, #767681);
@@ -146,7 +147,7 @@ const BoardRegisterPage = () => {
     if (titleValue && contentValue && spaceId != null) {
       //채팅방 생성 API 호출
       CreateBoardPostApi(
-        Number.parseInt(spaceId) || 3,
+        Number.parseInt(spaceId) || SPACE_ID,
         titleValue,
         contentValue,
         isNotice ? "notice" : "general",

--- a/src/pages/ChatPage/ChatCreatePage/ChatCreatePage.tsx
+++ b/src/pages/ChatPage/ChatCreatePage/ChatCreatePage.tsx
@@ -20,6 +20,7 @@ import {
   Member,
 } from "@/pages/ChatPage/ChatCreatePage/ChatCreatePage.styled";
 import { Explanation } from "@/pages/LoginPage/SignUpPage.styled";
+import { SPACE_ID } from "@/utils/constants";
 import { getUserDefaultImageURL } from "@/utils/getUserDefaultImageURL";
 import { svgComponentToFile } from "@/utils/svgComponentToFile";
 
@@ -29,7 +30,7 @@ const ChatCreatePage = () => {
   const [invitedMemberList, setInvitedMemberList] = useState<UserInfoInSpace[]>([]);
   const [memberList, setMemberList] = useState<UserInfoInSpace[]>([]);
   const [searchWord, setSearchWord] = useState<string>("");
-  const [spaceId, setSpaceId] = useState<number>(3);
+  const [spaceId, setSpaceId] = useState<number>(SPACE_ID);
 
   const [uploadedImage, setUploadedImage] = useState<File | null>(null);
   const defaultImage = svgComponentToFile(

--- a/src/pages/ChatPage/ChattingPage/ChattingPage.tsx
+++ b/src/pages/ChatPage/ChattingPage/ChattingPage.tsx
@@ -33,6 +33,7 @@ import {
   ImgPreview,
   StyledMessage,
 } from "@/pages/ChatPage/ChattingPage/ChattingPage.styled";
+import { SPACE_ID } from "@/utils/constants";
 import { decodedJWT } from "@/utils/decodedJWT";
 import { getUserDefaultImageURL } from "@/utils/getUserDefaultImageURL";
 import { isoStringToDateString } from "@/utils/isoStringToDateString";
@@ -46,7 +47,7 @@ const ChattingPage = () => {
   const {
     state: { chatroomInfo },
   }: { state: { chatroomInfo: Chatroom } } = useLocation();
-  const spaceId = Number(localStorage.getItem("spaceId")) || 3;
+  const spaceId = Number(localStorage.getItem("spaceId")) || SPACE_ID;
 
   const stompClient = useRef<any>(null);
 

--- a/src/pages/PayPage/ReqDataDiv.tsx
+++ b/src/pages/PayPage/ReqDataDiv.tsx
@@ -13,8 +13,6 @@ import * as s from "@/pages/PayPage/PayPage.styled";
 import "react-toastify/dist/ReactToastify.css";
 
 const ReqDataDiv = ({ data }: { data: PayReceiveInfo }) => {
-  const spaceID = 3;
-
   useEffect(() => {
     console.log(data);
   }, []);

--- a/src/pages/QRPage/QRDetail.tsx
+++ b/src/pages/QRPage/QRDetail.tsx
@@ -7,6 +7,7 @@ import QRDownIcon from "@/assets/QR/qr_down.svg";
 import QRShareIcon from "@/assets/QR/qr_share.svg";
 import ReactIcon from "@/assets/react.svg";
 import TopBarText, { LeftEnum } from "@/components/TopBarText";
+import { SPACE_ID } from "@/utils/constants";
 
 import { Member } from "../ChatPage/ChatCreatePage/ChatCreatePage.styled";
 import { RowFlexDiv } from "../PayPage/PayPage.styled";
@@ -17,7 +18,7 @@ const QRDetail = () => {
   const { id } = useParams();
 
   const url = window.location.origin + `/KUIT-Space-front/qr/${id}`;
-  const { data } = useEventQuery(1, Number(id), { refetchInterval: 10000 });
+  const { data } = useEventQuery(SPACE_ID, Number(id), { refetchInterval: 10000 });
   if (data == undefined) return <></>;
 
   const participants = data.result?.participants;
@@ -51,16 +52,16 @@ const QRDetail = () => {
         '<?xml version="1.0" standalone="no"?>' + serializer.serializeToString(_qrRef),
       );
 
-    let canvas = document.createElement("canvas");
+    const canvas = document.createElement("canvas");
     canvas.width = 1024;
     canvas.height = 1024;
 
-    let img = new Image();
-    let ctx = canvas.getContext("2d");
+    const img = new Image();
+    const ctx = canvas.getContext("2d");
     img.src = url;
     img.onload = () => {
       ctx?.drawImage(img, 0, 0);
-      let pngUrl = canvas.toDataURL("image/png");
+      const pngUrl = canvas.toDataURL("image/png");
       downloadData(pngUrl, name + ".png");
     };
     _qrRef.setAttribute("width", "188");

--- a/src/pages/QRPage/QRHome.tsx
+++ b/src/pages/QRPage/QRHome.tsx
@@ -10,6 +10,7 @@ import { BottomFloatBtn } from "@/components/BottomFloatBtn";
 import Modal from "@/components/Modal";
 import TopBarText, { LeftEnum } from "@/components/TopBarText";
 import * as s from "@/pages/QRPage/QRPage.styled";
+import { SPACE_ID } from "@/utils/constants";
 
 import { RowFlexDiv } from "../HomePage/HomePage.styled";
 
@@ -54,8 +55,8 @@ const QRHome = () => {
   const [isModal, setIsModal] = useState<boolean>(false);
   const [index, setIndex] = useState<number>(-1);
 
-  const { mutate: deleteEvent } = useDeleteEvent(1);
-  const { data } = useEventsQuery(1, { refetchInterval: 10000 });
+  const { mutate: deleteEvent } = useDeleteEvent(SPACE_ID);
+  const { data } = useEventsQuery(SPACE_ID, { refetchInterval: 10000 });
 
   if (data.result == undefined) {
     return <></>;

--- a/src/pages/QRPage/QRPage.tsx
+++ b/src/pages/QRPage/QRPage.tsx
@@ -6,6 +6,7 @@ import tmp from "@/assets/react.svg";
 import { BottomBtn } from "@/components/BottomBtn";
 import TopBarText, { LeftEnum } from "@/components/TopBarText";
 import * as s from "@/pages/QRPage/QRPage.styled";
+import { SPACE_ID } from "@/utils/constants";
 
 import { ColumnFlexDiv } from "../HomePage/HomePage.styled";
 
@@ -14,7 +15,7 @@ const QRPage = () => {
   const [title, setTitle] = useState<string>("");
   const [date, setDate] = useState<string>("");
   const [src, setSrc] = useState<string>("");
-  const { mutate: joinEvent } = useJoinEvent(1, Number(id));
+  const { mutate: joinEvent } = useJoinEvent(SPACE_ID, Number(id));
 
   const navigate = useNavigate();
   const onAttendClick = () => {
@@ -23,7 +24,7 @@ const QRPage = () => {
     navigate("/");
   };
 
-  const { data } = useEventQuery(1, Number(id), { refetchInterval: 10000 });
+  const { data } = useEventQuery(SPACE_ID, Number(id), { refetchInterval: 10000 });
   useEffect(() => {
     if (data.result == undefined) {
       return;

--- a/src/pages/VoiceRoomPage/EditVoiceRoomPage.tsx
+++ b/src/pages/VoiceRoomPage/EditVoiceRoomPage.tsx
@@ -1,11 +1,13 @@
-import TopBarText, { LeftEnum } from "@/components/TopBarText";
-import * as s from "@/pages/VoiceRoomPage/EditVoiceRoomPage.styled";
-import menu from "@/assets/VoiceRoom/icon_menu_icon.svg";
-import clear from "@/assets/VoiceRoom/icon_delete_X.svg";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+
 import { VrEditApi, VrListApi } from "@/apis/voiceroomApi";
+import clear from "@/assets/VoiceRoom/icon_delete_X.svg";
+import menu from "@/assets/VoiceRoom/icon_menu_icon.svg";
+import TopBarText, { LeftEnum } from "@/components/TopBarText";
+import * as s from "@/pages/VoiceRoomPage/EditVoiceRoomPage.styled";
 import { VrList } from "@/pages/VoiceRoomPage/VoiceRoomListPage";
+import { SPACE_ID } from "@/utils/constants";
 
 export type updateRoom = {
   roomId: number;
@@ -31,7 +33,7 @@ const EditVoiceRoomPage = () => {
 
   useEffect(() => {
     if (newRoomInfo.length > 0) {
-      VrEditApi(3, newRoomInfo).then(() => {
+      VrEditApi(SPACE_ID, newRoomInfo).then(() => {
         navigator("/voiceroom");
       });
     }
@@ -40,7 +42,7 @@ const EditVoiceRoomPage = () => {
   //_name 바뀔 이름
   const editVrList = (index: number, _name: string) => {
     if (vrList === undefined) return;
-    let temp = vrList.findIndex((value) => value.id === index);
+    const temp = vrList.findIndex((value) => value.id === index);
 
     vrList[temp].name = _name;
   };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const SPACE_ID = 3;


### PR DESCRIPTION
## Summary
하드코딩된 space ID 값(1과 3)을 중앙 집중식 SPACE_ID 상수로 대체하는 작업을 수행했습니다. 이를 통해 향후 space ID 값을 변경해야 할 경우 코드베이스 전체에서 모든 인스턴스를 찾아 수정하는 대신 한 곳에서만 수정하면 되므로 유지보수성이 향상됩니다.

## PR 유형 및 세부 작업 내용
- [x] 코드 리팩토링

### 세부 내용
1. 새로운 상수 파일 생성 (`src/utils/constants.ts`)에 SPACE_ID 상수 정의 (값: 3)
   - 애플리케이션 전체에서 사용할 수 있는 중앙 집중식 상수 파일 생성

2. 하드코딩된 space ID 값 3을 SPACE_ID 상수로 대체:
   - `src/pages/ChatPage/ChattingPage/ChattingPage.tsx`
     - `const spaceId = Number(localStorage.getItem("spaceId")) || 3;` → `const spaceId = Number(localStorage.getItem("spaceId")) || SPACE_ID;`
   - `src/pages/ChatPage/ChatCreatePage/ChatCreatePage.tsx`
     - `const [spaceId, setSpaceId] = useState<number>(3);` → `const [spaceId, setSpaceId] = useState<number>(SPACE_ID);`
   - `src/pages/VoiceRoomPage/EditVoiceRoomPage.tsx`
     - `VrEditApi(3, newRoomInfo)` → `VrEditApi(SPACE_ID, newRoomInfo)`
   - `src/pages/BoardPage/BoardRegisterPage/BoardRegisterPage.tsx`
     - `Number.parseInt(spaceId) || 3,` → `Number.parseInt(spaceId) || SPACE_ID,`
   - `src/pages/PayPage/ReqDataDiv.tsx`에서 사용되지 않는 `const spaceID = 3;` 변수 제거

3. 하드코딩된 space ID 값 1을 SPACE_ID 상수로 대체:
   - `src/pages/QRPage/QRPage.tsx`
     - `const { mutate: joinEvent } = useJoinEvent(1, Number(id));` → `const { mutate: joinEvent } = useJoinEvent(SPACE_ID, Number(id));`
     - `const { data } = useEventQuery(1, Number(id), { refetchInterval: 10000 });` → `const { data } = useEventQuery(SPACE_ID, Number(id), { refetchInterval: 10000 });`
   - `src/pages/QRPage/QRDetail.tsx`
     - `const { data } = useEventQuery(1, Number(id), { refetchInterval: 10000 });` → `const { data } = useEventQuery(SPACE_ID, Number(id), { refetchInterval: 10000 });`
   - `src/pages/QRPage/QRHome.tsx`
     - `const { mutate: deleteEvent } = useDeleteEvent(1);` → `const { mutate: deleteEvent } = useDeleteEvent(SPACE_ID);`
     - `const { data } = useEventsQuery(1, { refetchInterval: 10000 });` → `const { data } = useEventsQuery(SPACE_ID, { refetchInterval: 10000 });`

이 변경으로 코드의 일관성이 향상되고, 향후 space ID 값을 변경해야 할 경우 한 곳에서만 수정하면 되므로 유지보수가 용이해집니다. 또한 QR 페이지에서 사용하던 space ID 값 1을 프로젝트 전체에서 사용하는 값 3으로 통일하여 일관성을 높였습니다.
