### PR TITLE
이벤트 참가자 수 표시 버그 수정

### DIFF
--- a/documents/issues/event-participants-count-bug.md
+++ b/documents/issues/event-participants-count-bug.md
@@ -1,0 +1,46 @@
+## 어떤 버그인가요?
+useEventsQuery에서 events.participants를 사용하여 현재 참가 인원을 표시하고 있으나, swagger.json에 따르면 API는 events.totalNumberOfParticipants를 반환합니다.
+
+## 어떤 상황에서 발생한 버그인가요?
+- QRHome 컴포넌트에서 useEventsQuery를 통해 이벤트 목록을 가져올 때, 각 이벤트의 참가자 수를 표시하기 위해 event.participants.length를 사용합니다.
+- 그러나 swagger.json에 정의된 API 응답 구조에 따르면, 이벤트 목록 조회 API는 participants 배열이 아닌 totalNumberOfParticipants 필드를 반환합니다.
+- 이로 인해 API 응답과 프론트엔드 코드 간의 불일치가 발생하여 참가자 수가 제대로 표시되지 않을 수 있습니다.
+
+## 예상 결과
+- API 응답 타입이 swagger.json과 일치하도록 수정되어야 합니다.
+- 행사 참여 인원 수를 표시할 때 events.participants.length 대신 events.totalNumberOfParticipants를 사용해야 합니다.
+
+## 참고할만한 자료(선택)
+- swagger.json에 정의된 EventInfoResponse 타입:
+```json
+"EventInfoResponse": {
+  "type": "object",
+  "properties": {
+    "id": {"type": "integer", "format": "int64"},
+    "name": {"type": "string"},
+    "image": {"type": "string"},
+    "date": {"type": "string", "format": "date-time"},
+    "startTime": {"type": "string", "format": "date-time"},
+    "endTime": {"type": "string", "format": "date-time"},
+    "totalNumberOfParticipants": {"type": "integer", "format": "int32"}
+  }
+}
+```
+
+- 현재 프론트엔드 코드에서 정의된 ReadEventInfoResponse 타입:
+```typescript
+export interface ReadEventInfoResponse {
+  id: number;
+  name: string;
+  image: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  participants: EventParticipantInfo[];
+}
+```
+
+- 수정이 필요한 파일:
+  - src/apis/event/index.ts
+  - src/pages/QRPage/QRHome.tsx
+  - src/pages/QRPage/QRDetail.tsx

--- a/documents/pull-requests/fix-event-participants-count-bug-PR.md
+++ b/documents/pull-requests/fix-event-participants-count-bug-PR.md
@@ -1,0 +1,22 @@
+## Summary
+
+이벤트 참가자 수 표시 버그를 수정했습니다. useEventsQuery에서 events.participants.length를 사용하여 현재 참가 인원을 표시하고 있었으나, swagger.json에 따르면 API는 events.totalNumberOfParticipants를 반환합니다. 이로 인해 API 응답과 프론트엔드 코드 간의 불일치가 발생하여 참가자 수가 제대로 표시되지 않았습니다.
+
+
+## PR 유형 및 세부 작업 내용
+
+- [x] 버그 수정
+
+### 세부 내용
+1. `src/apis/event/index.ts` 파일에서 `EventInfoResponse` 인터페이스에 `totalNumberOfParticipants` 필드 추가
+2. `ReadEventsResponse` 인터페이스가 `EventInfoResponse`를 사용하도록 수정
+3. `QRHome.tsx` 컴포넌트에서 `event.participants.length` 대신 `event.totalNumberOfParticipants`를 사용하도록 수정
+4. `QRDetail.tsx` 컴포넌트는 `useEventQuery`를 사용하여 단일 이벤트 정보를 가져오며, 이는 `participants` 배열을 포함하는 `ReadEventInfoResponse`를 반환하므로 수정이 필요하지 않음을 확인
+
+## 테스트 완료 여부
+- [x] QRHome 페이지에서 이벤트 참가자 수가 올바르게 표시되는지 확인
+- [x] QRDetail 페이지에서 참가자 목록과 수가 올바르게 표시되는지 확인
+
+## 리뷰 요구사항
+- API 응답 타입과 프론트엔드 코드 간의 일치성 확인
+- 참가자 수 표시 로직의 정확성 확인

--- a/src/apis/event/index.ts
+++ b/src/apis/event/index.ts
@@ -16,13 +16,14 @@ export const eventKeys = {
   detail: (spaceId: number, eventId: number) => [...eventKeys.details(spaceId), eventId] as const,
 };
 
-interface EventInfoResponse {
+export interface EventInfoResponse {
   id: number;
   name: string;
   image: string;
   date: string;
   startTime: string;
   endTime: string;
+  totalNumberOfParticipants: number;
 }
 
 interface EventParticipantInfo {
@@ -32,7 +33,7 @@ interface EventParticipantInfo {
 }
 
 interface ReadEventsResponse {
-  events: ReadEventInfoResponse[];
+  events: EventInfoResponse[];
 }
 
 export interface ReadEventInfoResponse {

--- a/src/pages/QRPage/QRHome.tsx
+++ b/src/pages/QRPage/QRHome.tsx
@@ -1,7 +1,12 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { ReadEventInfoResponse, useDeleteEvent, useEventsQuery } from "@/apis/event";
+import {
+  EventInfoResponse,
+  ReadEventInfoResponse,
+  useDeleteEvent,
+  useEventsQuery,
+} from "@/apis/event";
 import QRCreateIcon from "@/assets/QR/qr_create.svg";
 import QRDelete from "@/assets/QR/qr_delete.svg";
 import QREdit from "@/assets/QR/qr_edit.svg";
@@ -18,7 +23,7 @@ const QRAttendWrapper = ({
   event,
   handler,
 }: {
-  event: ReadEventInfoResponse;
+  event: EventInfoResponse;
   handler: (i: number) => void;
 }) => {
   const navigate = useNavigate();
@@ -40,9 +45,7 @@ const QRAttendWrapper = ({
           <s.QRAttendTitle>{event.name}</s.QRAttendTitle>
           <RowFlexDiv>
             <s.QRAttendContent1>현재 참가 인원&nbsp;</s.QRAttendContent1>
-            <s.QRAttendContent2>
-              {!event.participants ? 0 : event.participants.length}
-            </s.QRAttendContent2>
+            <s.QRAttendContent2>{event.totalNumberOfParticipants ?? 0}</s.QRAttendContent2>
             <s.QRAttendContent1>명</s.QRAttendContent1>
           </RowFlexDiv>
           <s.QRAttendDate>{event.date}</s.QRAttendDate>
@@ -61,7 +64,7 @@ const QRHome = () => {
   if (data.result == undefined) {
     return <></>;
   }
-  const events: ReadEventInfoResponse[] = data.result.events;
+  const events: EventInfoResponse[] = data.result.events;
 
   const togleModal = (i: number) => {
     setIsModal(!isModal);


### PR DESCRIPTION
## Summary

이벤트 참가자 수 표시 버그를 수정했습니다. useEventsQuery에서 events.participants.length를 사용하여 현재 참가 인원을 표시하고 있었으나, swagger.json에 따르면 API는 events.totalNumberOfParticipants를 반환합니다. 이로 인해 API 응답과 프론트엔드 코드 간의 불일치가 발생하여 참가자 수가 제대로 표시되지 않았습니다.

## PR 유형 및 세부 작업 내용

- [x] 버그 수정

### 세부 내용
1. `src/apis/event/index.ts` 파일에서 `EventInfoResponse` 인터페이스에 `totalNumberOfParticipants` 필드 추가
2. `ReadEventsResponse` 인터페이스가 `EventInfoResponse`를 사용하도록 수정
3. `QRHome.tsx` 컴포넌트에서 `event.participants.length` 대신 `event.totalNumberOfParticipants`를 사용하도록 수정
4. `QRDetail.tsx` 컴포넌트는 `useEventQuery`를 사용하여 단일 이벤트 정보를 가져오며, 이는 `participants` 배열을 포함하는 `ReadEventInfoResponse`를 반환하므로 수정이 필요하지 않음을 확인

## 테스트 완료 여부
- [x] QRHome 페이지에서 이벤트 참가자 수가 올바르게 표시되는지 확인
- [x] QRDetail 페이지에서 참가자 목록과 수가 올바르게 표시되는지 확인

## 리뷰 요구사항
- API 응답 타입과 프론트엔드 코드 간의 일치성 확인
- 참가자 수 표시 로직의 정확성 확인

## 실행 결과
![실행 결과 이미지](https://github.com/user-attachments/assets/cd8157ff-508b-4273-91b8-7acd62c6b0c7)


