### PR TITLE
정산 API 연동

### DIFF
--- a/documents/guides/pay-api-cache-strategy.md
+++ b/documents/guides/pay-api-cache-strategy.md
@@ -1,0 +1,76 @@
+# Pay API 캐싱 전략 가이드
+
+## 개요
+
+이 문서는 정산 API(Pay API)의 React Query 캐싱 전략에 대한 결정사항을 정리한 것입니다. 금전 관련 데이터를 다루는 특성상 실시간성과 사용자 경험(UX) 사이의 균형을 고려하여 최적의 전략을 수립했습니다.
+
+## Pay API 특성
+
+- 최대 40명 정도의 사용자가 상호작용하는 정산 시스템
+- 초 단위로 금액이 바뀌진 않지만, 금전 관련 정보이므로 적절한 실시간성 필요
+- 사용자 액션(정산 요청, 완료 등)에 따라 데이터 변경 발생
+
+## 캐싱 전략 결정사항
+
+### 1. React Query 설정
+
+```typescript
+// 권장 설정
+{
+  staleTime: 10 * 1000, // 10초
+  cacheTime: 60 * 1000, // 1분
+  refetchOnWindowFocus: true,
+  refetchOnReconnect: true
+}
+```
+
+**staleTime (0초)**
+- 데이터가 빠르게 stale 상태가 되도록 짧게 설정
+- 이를 통해 컴포넌트가 마운트되거나 윈도우 포커스 시 background refetch 발생
+
+**cacheTime (30초~1분)**
+- 완전히 0으로 설정하지 않고 적절한 값 유지
+- 사용자가 페이지를 이동했다가 돌아왔을 때 로딩 화면을 최소화하여 UX 개선
+- 서버 부하 및 네트워크 트래픽 감소
+
+### 2. Mutation 후 데이터 무효화
+
+현재 구현된 대로 mutation 성공 후 관련 쿼리를 무효화하는 전략을 유지합니다:
+
+```typescript
+// 예: useCreatePay mutation
+export const useCreatePay = (spaceId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: RequestOfCreatePay) => createPay(spaceId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: payKeys.home(spaceId) });
+      queryClient.invalidateQueries({ queryKey: payKeys.request(spaceId) });
+    },
+  });
+};
+```
+
+### 3. 주요 화면의 자동 갱신 설정
+
+정산 현황을 보여주는 주요 화면에서는 refetchInterval을 활용한 주기적 갱신 고려:
+
+```typescript
+// 주요 화면에서의 사용 예시
+const { data } = usePayHomeQuery(spaceId, {
+  refetchInterval: 30 * 1000, // 30초마다 갱신
+});
+```
+
+### 4. UI/UX 개선 방안
+
+데이터의 신선도와 관련하여 사용자에게 투명성을 제공하기 위한 UI/UX 개선 방안:
+
+- 마지막 데이터 업데이트 시간 표시
+- 수동 새로고침 버튼 제공
+- 데이터 로딩/fetching 상태를 명확히 표시
+
+## 결론
+
+cacheTime을 0으로 설정하는 극단적인 방법보다는, React Query의 다양한 기능(staleTime, refetchOnFocus, mutation 후 invalidation 등)을 활용하여 실시간성과 사용자 경험 사이의 균형을 맞추는 것이 효과적입니다. 이를 통해 데이터의 정확성은 유지하면서도 사용자에게 매끄러운 경험을 제공할 수 있습니다.

--- a/documents/guides/pay-api-cache-strategy.md
+++ b/documents/guides/pay-api-cache-strategy.md
@@ -63,14 +63,6 @@ const { data } = usePayHomeQuery(spaceId, {
 });
 ```
 
-### 4. UI/UX 개선 방안
-
-데이터의 신선도와 관련하여 사용자에게 투명성을 제공하기 위한 UI/UX 개선 방안:
-
-- 마지막 데이터 업데이트 시간 표시
-- 수동 새로고침 버튼 제공
-- 데이터 로딩/fetching 상태를 명확히 표시
-
 ## 결론
 
 cacheTime을 0으로 설정하는 극단적인 방법보다는, React Query의 다양한 기능(staleTime, refetchOnFocus, mutation 후 invalidation 등)을 활용하여 실시간성과 사용자 경험 사이의 균형을 맞추는 것이 효과적입니다. 이를 통해 데이터의 정확성은 유지하면서도 사용자에게 매끄러운 경험을 제공할 수 있습니다.

--- a/documents/pull-requests/pay-api-react-query.md
+++ b/documents/pull-requests/pay-api-react-query.md
@@ -1,0 +1,36 @@
+## Summary
+Pay API를 ky 클라이언트와 React Query를 이용하여 리팩토링했습니다. 이를 통해 캐싱 전략을 적용하고 데이터 페칭 로직을 표준화하였습니다.
+
+## PR 유형 및 세부 작업 내용
+- [x] 코드 리팩토링
+
+#### 세부 내용
+1. Pay 도메인 관련 TypeScript 인터페이스 정의
+   - 스웨거 문서 기반 타입 정의
+   - 백엔드 API 응답 타입 구현
+
+2. ky 클라이언트를 이용하여 API 함수 구현
+   - 기존 fetch 사용 코드를 ky로 마이그레이션
+   - 에러 핸들링 및 응답 타입 적용
+
+3. React Query 쿼리 키 생성
+   - 도메인별 일관된 쿼리 키 구조 적용
+   - 캐시 무효화를 위한 계층 구조 설계
+
+4. useQuery와 useMutation 훅 구현
+   - GET 요청을 위한 useQuery 커스텀 훅 구현
+   - POST, PATCH, DELETE 요청을 위한 useMutation 커스텀 훅 구현
+   - Naming Convention 적용 (useNounQuery, useVerbResource)
+
+5. 캐싱 전략 적용
+   - gcTime 30초 설정으로 적절한 데이터 캐싱 전략 구현
+   - refetchInterval 설정을 통해 30초마나 refetching하여 약간의 실시간성 보장
+   - 상태 변경 시 관련 쿼리 무효화 로직 추가
+
+## 작동 스크린샷
+API 코드 리팩토링이므로 UI 변경 없음
+
+## 리뷰 요구사항
+- 네이밍 컨벤션이 일관되게 적용되었는지 확인
+- 캐싱 전략이 적절한지 검토
+- 쿼리 무효화 로직이 필요한 곳에 모두 적용되었는지 확인

--- a/src/apis/Pay/index.ts
+++ b/src/apis/Pay/index.ts
@@ -1,0 +1,94 @@
+import { ApiResponse } from "../client";
+
+export interface TargetOfPayRequest {
+  targetMemberId: number;
+  requestedAmount: number;
+}
+
+export interface RequestOfCreatePay {
+  totalAmount: number;
+  bankName: string;
+  bankAccountNum: string;
+  targets: TargetOfPayRequest[];
+  valueOfPayType?: string;
+}
+
+export interface ResponseOfCreatePay {
+  payRequestId: number;
+}
+
+export interface PayRequestInfoInHome {
+  payRequestId: number;
+  totalAmount: number;
+  receivedAmount: number;
+  totalTargetNum: number;
+  sendCompleteTargetNum: number;
+}
+
+export interface RequestedPayInfoInHome {
+  payRequestTargetId: number;
+  payCreatorName: string;
+  payCreatorProfileImgUrl: string;
+  requestedAmount: number;
+}
+
+export interface ResponseOfReadPayHome {
+  requestInfoInHome: PayRequestInfoInHome[];
+  requestedPayInfoInHome: RequestedPayInfoInHome[];
+}
+
+export interface ResponseOfTargetDetail {
+  targetMemberId: number;
+  targetMemberName: string;
+  targetMemberProfileImageUrl: string;
+  requestedAmount: number;
+  complete: boolean;
+}
+
+export interface ResponseOfReadPayDetail {
+  payRequestId: number;
+  totalAmount: number;
+  receivedAmount: number;
+  totalTargetNum: number;
+  sendCompleteTargetNum: number;
+  bankName: string;
+  bankAccountNum: string;
+  createdDate: string;
+  responseOfTargetDetails: ResponseOfTargetDetail[];
+}
+
+export interface ResponseOfPayRequestInfo {
+  payRequestId: number;
+  totalAmount: number;
+  receivedAmount: number;
+  totalTargetNum: number;
+  sendCompleteTargetNum: number;
+}
+
+export interface ResponseOfReadPayRequestList {
+  completePayRequestList: ResponseOfPayRequestInfo[];
+  inCompletePayRequestList: ResponseOfPayRequestInfo[];
+}
+
+export interface ResponseOfRequestedPayInfo {
+  payRequestTargetId: number;
+  payCreatorName: string;
+  payCreatorProfileImageUrl: string;
+  requestedAmount: number;
+  bankName: string;
+  bankAccountNum: string;
+}
+
+export interface ResponseOfReadRequestedPayList {
+  completeRequestedPayList: ResponseOfRequestedPayInfo[];
+  inCompleteRequestedPayList: ResponseOfRequestedPayInfo[];
+}
+
+export interface BankInfo {
+  bankName: string;
+  bankAccountNumber: string;
+}
+
+export interface ResponseOfBankInfo {
+  bankInfos: BankInfo[];
+}

--- a/src/apis/Pay/index.ts
+++ b/src/apis/Pay/index.ts
@@ -124,6 +124,7 @@ export const usePayHomeQuery = (
   return useSuspenseQuery({
     queryKey: payKeys.home(spaceId),
     queryFn: () => getPayHome(spaceId),
+    gcTime: 30 * 1000,
     ...options,
   });
 };
@@ -150,6 +151,7 @@ export const usePayDetailQuery = (
   return useSuspenseQuery({
     queryKey: payKeys.detail(spaceId, payRequestId),
     queryFn: () => getPayDetail(spaceId, payRequestId),
+    gcTime: 30 * 1000,
     ...options,
   });
 };
@@ -174,6 +176,7 @@ export const useRequestedPayListQuery = (
   return useSuspenseQuery({
     queryKey: payKeys.requested(spaceId),
     queryFn: () => getRequestedPayList(spaceId),
+    gcTime: 30 * 1000,
     ...options,
   });
 };
@@ -198,6 +201,7 @@ export const usePayRequestListQuery = (
   return useSuspenseQuery({
     queryKey: payKeys.request(spaceId),
     queryFn: () => getPayRequestList(spaceId),
+    gcTime: 30 * 1000,
     ...options,
   });
 };
@@ -220,6 +224,7 @@ export const useBankInfoQuery = (
   return useSuspenseQuery({
     queryKey: payKeys.bank(spaceId),
     queryFn: () => getBankInfo(spaceId),
+    gcTime: 30 * 1000,
     ...options,
   });
 };

--- a/src/apis/Pay/index.ts
+++ b/src/apis/Pay/index.ts
@@ -1,4 +1,4 @@
-import { ApiResponse } from "../client";
+import { ApiResponse, client } from "../client";
 
 export interface TargetOfPayRequest {
   targetMemberId: number;
@@ -12,6 +12,58 @@ export interface RequestOfCreatePay {
   targets: TargetOfPayRequest[];
   valueOfPayType?: string;
 }
+
+export const getPayHome = async (spaceId: number): Promise<ApiResponse<ResponseOfReadPayHome>> => {
+  return client.get(`space/${spaceId}/pay`).json();
+};
+
+export const getPayDetail = async (
+  spaceId: number,
+  payRequestId: number,
+): Promise<ApiResponse<ResponseOfReadPayDetail>> => {
+  return client.get(`space/${spaceId}/pay/${payRequestId}`).json();
+};
+
+export const createPay = async (
+  spaceId: number,
+  data: RequestOfCreatePay,
+): Promise<ApiResponse<ResponseOfCreatePay>> => {
+  return client
+    .post(`space/${spaceId}/pay/create`, {
+      json: data,
+    })
+    .json();
+};
+
+export const completePay = async (
+  spaceId: number,
+  payRequestTargetId: number,
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return client.patch(`space/${spaceId}/pay/${payRequestTargetId}/complete`).json();
+};
+
+export const getRequestedPayList = async (
+  spaceId: number,
+): Promise<ApiResponse<ResponseOfReadRequestedPayList>> => {
+  return client.get(`space/${spaceId}/pay/requested`).json();
+};
+
+export const getPayRequestList = async (
+  spaceId: number,
+): Promise<ApiResponse<ResponseOfReadPayRequestList>> => {
+  return client.get(`space/${spaceId}/pay/request`).json();
+};
+
+export const getBankInfo = async (spaceId: number): Promise<ApiResponse<ResponseOfBankInfo>> => {
+  return client.get(`space/${spaceId}/pay/bank`).json();
+};
+
+export const deletePay = async (
+  spaceId: number,
+  payRequestId: number,
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return client.delete(`space/${spaceId}/pay/${payRequestId}`).json();
+};
 
 export interface ResponseOfCreatePay {
   payRequestId: number;

--- a/src/apis/Pay/index.ts
+++ b/src/apis/Pay/index.ts
@@ -1,14 +1,6 @@
-import { ApiResponse, client } from "../client";
+import { useSuspenseQuery, UseSuspenseQueryOptions } from "@tanstack/react-query";
 
-export const payKeys = {
-  all: (spaceId: number) => ["pay", spaceId] as const,
-  home: (spaceId: number) => [...payKeys.all(spaceId), "home"] as const,
-  detail: (spaceId: number, payRequestId: number) =>
-    [...payKeys.all(spaceId), "detail", payRequestId] as const,
-  requested: (spaceId: number) => [...payKeys.all(spaceId), "requested"] as const,
-  request: (spaceId: number) => [...payKeys.all(spaceId), "request"] as const,
-  bank: (spaceId: number) => [...payKeys.all(spaceId), "bank"] as const,
-};
+import { ApiResponse, client } from "../client";
 
 export interface TargetOfPayRequest {
   targetMemberId: number;
@@ -22,58 +14,6 @@ export interface RequestOfCreatePay {
   targets: TargetOfPayRequest[];
   valueOfPayType?: string;
 }
-
-export const getPayHome = async (spaceId: number): Promise<ApiResponse<ResponseOfReadPayHome>> => {
-  return client.get(`space/${spaceId}/pay`).json();
-};
-
-export const getPayDetail = async (
-  spaceId: number,
-  payRequestId: number,
-): Promise<ApiResponse<ResponseOfReadPayDetail>> => {
-  return client.get(`space/${spaceId}/pay/${payRequestId}`).json();
-};
-
-export const createPay = async (
-  spaceId: number,
-  data: RequestOfCreatePay,
-): Promise<ApiResponse<ResponseOfCreatePay>> => {
-  return client
-    .post(`space/${spaceId}/pay/create`, {
-      json: data,
-    })
-    .json();
-};
-
-export const completePay = async (
-  spaceId: number,
-  payRequestTargetId: number,
-): Promise<ApiResponse<{ success: boolean }>> => {
-  return client.patch(`space/${spaceId}/pay/${payRequestTargetId}/complete`).json();
-};
-
-export const getRequestedPayList = async (
-  spaceId: number,
-): Promise<ApiResponse<ResponseOfReadRequestedPayList>> => {
-  return client.get(`space/${spaceId}/pay/requested`).json();
-};
-
-export const getPayRequestList = async (
-  spaceId: number,
-): Promise<ApiResponse<ResponseOfReadPayRequestList>> => {
-  return client.get(`space/${spaceId}/pay/request`).json();
-};
-
-export const getBankInfo = async (spaceId: number): Promise<ApiResponse<ResponseOfBankInfo>> => {
-  return client.get(`space/${spaceId}/pay/bank`).json();
-};
-
-export const deletePay = async (
-  spaceId: number,
-  payRequestId: number,
-): Promise<ApiResponse<{ success: boolean }>> => {
-  return client.delete(`space/${spaceId}/pay/${payRequestId}`).json();
-};
 
 export interface ResponseOfCreatePay {
   payRequestId: number;
@@ -154,3 +94,156 @@ export interface BankInfo {
 export interface ResponseOfBankInfo {
   bankInfos: BankInfo[];
 }
+
+export const payKeys = {
+  all: (spaceId: number) => ["pay", spaceId] as const,
+  home: (spaceId: number) => [...payKeys.all(spaceId), "home"] as const,
+  detail: (spaceId: number, payRequestId: number) =>
+    [...payKeys.all(spaceId), "detail", payRequestId] as const,
+  requested: (spaceId: number) => [...payKeys.all(spaceId), "requested"] as const,
+  request: (spaceId: number) => [...payKeys.all(spaceId), "request"] as const,
+  bank: (spaceId: number) => [...payKeys.all(spaceId), "bank"] as const,
+};
+
+export const getPayHome = async (spaceId: number): Promise<ApiResponse<ResponseOfReadPayHome>> => {
+  return client.get(`space/${spaceId}/pay`).json();
+};
+
+export const usePayHomeQuery = (
+  spaceId: number,
+  options?: Partial<
+    UseSuspenseQueryOptions<
+      ApiResponse<ResponseOfReadPayHome>,
+      Error,
+      ApiResponse<ResponseOfReadPayHome>,
+      ReturnType<typeof payKeys.home>
+    >
+  >,
+) => {
+  return useSuspenseQuery({
+    queryKey: payKeys.home(spaceId),
+    queryFn: () => getPayHome(spaceId),
+    ...options,
+  });
+};
+
+export const getPayDetail = async (
+  spaceId: number,
+  payRequestId: number,
+): Promise<ApiResponse<ResponseOfReadPayDetail>> => {
+  return client.get(`space/${spaceId}/pay/${payRequestId}`).json();
+};
+
+export const usePayDetailQuery = (
+  spaceId: number,
+  payRequestId: number,
+  options?: Partial<
+    UseSuspenseQueryOptions<
+      ApiResponse<ResponseOfReadPayDetail>,
+      Error,
+      ApiResponse<ResponseOfReadPayDetail>,
+      ReturnType<typeof payKeys.detail>
+    >
+  >,
+) => {
+  return useSuspenseQuery({
+    queryKey: payKeys.detail(spaceId, payRequestId),
+    queryFn: () => getPayDetail(spaceId, payRequestId),
+    ...options,
+  });
+};
+
+export const getRequestedPayList = async (
+  spaceId: number,
+): Promise<ApiResponse<ResponseOfReadRequestedPayList>> => {
+  return client.get(`space/${spaceId}/pay/requested`).json();
+};
+
+export const useRequestedPayListQuery = (
+  spaceId: number,
+  options?: Partial<
+    UseSuspenseQueryOptions<
+      ApiResponse<ResponseOfReadRequestedPayList>,
+      Error,
+      ApiResponse<ResponseOfReadRequestedPayList>,
+      ReturnType<typeof payKeys.requested>
+    >
+  >,
+) => {
+  return useSuspenseQuery({
+    queryKey: payKeys.requested(spaceId),
+    queryFn: () => getRequestedPayList(spaceId),
+    ...options,
+  });
+};
+
+export const getPayRequestList = async (
+  spaceId: number,
+): Promise<ApiResponse<ResponseOfReadPayRequestList>> => {
+  return client.get(`space/${spaceId}/pay/request`).json();
+};
+
+export const usePayRequestListQuery = (
+  spaceId: number,
+  options?: Partial<
+    UseSuspenseQueryOptions<
+      ApiResponse<ResponseOfReadPayRequestList>,
+      Error,
+      ApiResponse<ResponseOfReadPayRequestList>,
+      ReturnType<typeof payKeys.request>
+    >
+  >,
+) => {
+  return useSuspenseQuery({
+    queryKey: payKeys.request(spaceId),
+    queryFn: () => getPayRequestList(spaceId),
+    ...options,
+  });
+};
+
+export const getBankInfo = async (spaceId: number): Promise<ApiResponse<ResponseOfBankInfo>> => {
+  return client.get(`space/${spaceId}/pay/bank`).json();
+};
+
+export const useBankInfoQuery = (
+  spaceId: number,
+  options?: Partial<
+    UseSuspenseQueryOptions<
+      ApiResponse<ResponseOfBankInfo>,
+      Error,
+      ApiResponse<ResponseOfBankInfo>,
+      ReturnType<typeof payKeys.bank>
+    >
+  >,
+) => {
+  return useSuspenseQuery({
+    queryKey: payKeys.bank(spaceId),
+    queryFn: () => getBankInfo(spaceId),
+    ...options,
+  });
+};
+
+export const createPay = async (
+  spaceId: number,
+  data: RequestOfCreatePay,
+): Promise<ApiResponse<ResponseOfCreatePay>> => {
+  return client
+    .post(`space/${spaceId}/pay/create`, {
+      json: data,
+    })
+    .json();
+};
+
+export const completePay = async (
+  spaceId: number,
+  payRequestTargetId: number,
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return client.patch(`space/${spaceId}/pay/${payRequestTargetId}/complete`).json();
+};
+
+export const deletePay = async (
+  spaceId: number,
+  payRequestId: number,
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return client.delete(`space/${spaceId}/pay/${payRequestId}`).json();
+};

--- a/src/apis/Pay/index.ts
+++ b/src/apis/Pay/index.ts
@@ -106,7 +106,7 @@ export const payKeys = {
   bank: (spaceId: number) => [...payKeys.all(spaceId), "bank"] as const,
 };
 
-export const getPayHome = async (spaceId: number): Promise<ApiResponse<ResponseOfReadPayHome>> => {
+const getPayHome = async (spaceId: number): Promise<ApiResponse<ResponseOfReadPayHome>> => {
   return client.get(`space/${spaceId}/pay`).json();
 };
 
@@ -128,7 +128,7 @@ export const usePayHomeQuery = (
   });
 };
 
-export const getPayDetail = async (
+const getPayDetail = async (
   spaceId: number,
   payRequestId: number,
 ): Promise<ApiResponse<ResponseOfReadPayDetail>> => {
@@ -154,7 +154,7 @@ export const usePayDetailQuery = (
   });
 };
 
-export const getRequestedPayList = async (
+const getRequestedPayList = async (
   spaceId: number,
 ): Promise<ApiResponse<ResponseOfReadRequestedPayList>> => {
   return client.get(`space/${spaceId}/pay/requested`).json();
@@ -178,7 +178,7 @@ export const useRequestedPayListQuery = (
   });
 };
 
-export const getPayRequestList = async (
+const getPayRequestList = async (
   spaceId: number,
 ): Promise<ApiResponse<ResponseOfReadPayRequestList>> => {
   return client.get(`space/${spaceId}/pay/request`).json();
@@ -202,7 +202,7 @@ export const usePayRequestListQuery = (
   });
 };
 
-export const getBankInfo = async (spaceId: number): Promise<ApiResponse<ResponseOfBankInfo>> => {
+const getBankInfo = async (spaceId: number): Promise<ApiResponse<ResponseOfBankInfo>> => {
   return client.get(`space/${spaceId}/pay/bank`).json();
 };
 
@@ -224,7 +224,7 @@ export const useBankInfoQuery = (
   });
 };
 
-export const createPay = async (
+const createPay = async (
   spaceId: number,
   data: RequestOfCreatePay,
 ): Promise<ApiResponse<ResponseOfCreatePay>> => {
@@ -247,7 +247,7 @@ export const useCreatePay = (spaceId: number) => {
   });
 };
 
-export const completePay = async (
+const completePay = async (
   spaceId: number,
   payRequestTargetId: number,
 ): Promise<ApiResponse<{ success: boolean }>> => {
@@ -268,7 +268,7 @@ export const useCompletePay = (spaceId: number) => {
   });
 };
 
-export const deletePay = async (
+const deletePay = async (
   spaceId: number,
   payRequestId: number,
 ): Promise<ApiResponse<{ success: boolean }>> => {

--- a/src/apis/Pay/index.ts
+++ b/src/apis/Pay/index.ts
@@ -1,5 +1,15 @@
 import { ApiResponse, client } from "../client";
 
+export const payKeys = {
+  all: (spaceId: number) => ["pay", spaceId] as const,
+  home: (spaceId: number) => [...payKeys.all(spaceId), "home"] as const,
+  detail: (spaceId: number, payRequestId: number) =>
+    [...payKeys.all(spaceId), "detail", payRequestId] as const,
+  requested: (spaceId: number) => [...payKeys.all(spaceId), "requested"] as const,
+  request: (spaceId: number) => [...payKeys.all(spaceId), "request"] as const,
+  bank: (spaceId: number) => [...payKeys.all(spaceId), "bank"] as const,
+};
+
 export interface TargetOfPayRequest {
   targetMemberId: number;
   requestedAmount: number;

--- a/src/apis/Pay/index.ts
+++ b/src/apis/Pay/index.ts
@@ -125,6 +125,7 @@ export const usePayHomeQuery = (
     queryKey: payKeys.home(spaceId),
     queryFn: () => getPayHome(spaceId),
     gcTime: 30 * 1000,
+    refetchInterval: 30 * 1000,
     ...options,
   });
 };
@@ -152,6 +153,7 @@ export const usePayDetailQuery = (
     queryKey: payKeys.detail(spaceId, payRequestId),
     queryFn: () => getPayDetail(spaceId, payRequestId),
     gcTime: 30 * 1000,
+    refetchInterval: 30 * 1000,
     ...options,
   });
 };
@@ -177,6 +179,7 @@ export const useRequestedPayListQuery = (
     queryKey: payKeys.requested(spaceId),
     queryFn: () => getRequestedPayList(spaceId),
     gcTime: 30 * 1000,
+    refetchInterval: 30 * 1000,
     ...options,
   });
 };
@@ -202,6 +205,7 @@ export const usePayRequestListQuery = (
     queryKey: payKeys.request(spaceId),
     queryFn: () => getPayRequestList(spaceId),
     gcTime: 30 * 1000,
+    refetchInterval: 30 * 1000,
     ...options,
   });
 };
@@ -225,6 +229,7 @@ export const useBankInfoQuery = (
     queryKey: payKeys.bank(spaceId),
     queryFn: () => getBankInfo(spaceId),
     gcTime: 30 * 1000,
+    refetchInterval: 30 * 1000,
     ...options,
   });
 };


### PR DESCRIPTION
## Summary
Pay API를 ky 클라이언트와 React Query를 이용하여 리팩토링했습니다. 이를 통해 캐싱 전략을 적용하고 데이터 페칭 로직을 표준화하였습니다.

## PR 유형 및 세부 작업 내용
- [x] 코드 리팩토링

#### 세부 내용
1. Pay 도메인 관련 TypeScript 인터페이스 정의
   - 스웨거 문서 기반 타입 정의
   - 백엔드 API 응답 타입 구현

2. ky 클라이언트를 이용하여 API 함수 구현
   - 기존 fetch 사용 코드를 ky로 마이그레이션
   - 에러 핸들링 및 응답 타입 적용

3. React Query 쿼리 키 생성
   - 도메인별 일관된 쿼리 키 구조 적용
   - 캐시 무효화를 위한 계층 구조 설계

4. useQuery와 useMutation 훅 구현
   - GET 요청을 위한 useQuery 커스텀 훅 구현
   - POST, PATCH, DELETE 요청을 위한 useMutation 커스텀 훅 구현
   - Naming Convention 적용 (useNounQuery, useVerbResource)

5. 캐싱 전략 적용
   - gcTime 30초 설정으로 적절한 데이터 캐싱 전략 구현
   - refetchInterval 설정을 통해 30초마나 refetching하여 약간의 실시간성 보장
   - 상태 변경 시 관련 쿼리 무효화 로직 추가

## 작동 스크린샷
API 코드 리팩토링이므로 UI 변경 없음

## 리뷰 요구사항
- 네이밍 컨벤션이 일관되게 적용되었는지 확인
- 캐싱 전략이 적절한지 검토
- 쿼리 무효화 로직이 필요한 곳에 모두 적용되었는지 확인
