### PR TITLE
성공적으로 로그인 후에 /login으로 리다이렉트되지 않도록 수정

### DIFF
--- a/src/apis/oauth/index.ts
+++ b/src/apis/oauth/index.ts
@@ -1,4 +1,4 @@
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 
 import { useAuthStore } from "../../store/authStore";
 import { ApiResponse, client } from "../client";
@@ -74,11 +74,14 @@ export const useExchangeCodeForTokens = (options?: {
   ) => void;
   onError?: (error: Error) => void;
 }) => {
+  const { login } = useAuthStore();
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (code: string) => exchangeCodeForTokens(code),
     onSuccess: (data) => {
       if (data.accessToken && data.refreshToken) {
-        storeTokens(data.accessToken, data.refreshToken);
+        login(data.accessToken, data.refreshToken);
+        queryClient.invalidateQueries({ queryKey: ["auth"] });
       }
       options?.onSuccess?.(data);
     },


### PR DESCRIPTION
## Summary

useAuthQuery에서 앱이 한번 실행된 이후로 queryFn을 재실행하지 않아서, isAuthenticated 값이 바뀌지 않던 이슈를 해결했습니다.

## PR 유형 및 세부 작업 내용
- [x] 버그 수정

## test 완료 여부 (선택)
테스트 완료

## 작동 스크린샷 (선택)

## 리뷰 요구사항 (선택)
